### PR TITLE
Add support for Log4Net Context Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,42 @@ var log = new LoggerConfiguration()
     .CreateLogger();
 ```
 
+#### Context Message Marker
+Passing `true` for supplyContextMessage, will add a context message of `Serilog-Log4NetSink` scoped just for the log call under the `NDC` stack, which you can utilise for Log4Net filters and other purposes. [See Log4Net documentation](https://logging.apache.org/log4net/release/manual/contexts.html#stacks).
+
+e.g.
+
+```csharp
+var log = new LoggerConfiguration()
+    .WriteTo.Log4Net(supplyContextMessage: true)
+    .CreateLogger();
+```
+
+This can let you specify a filter on an appender in Log4Net. The example below, disables the Seq appender for Log4Net if the context message is present. Useful to stop doubling up logs, for when you have Log4Net and Serilog both pushing to the same sink during migration of logging practices.
+
+```xml
+<log4net>
+  <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
+    <layout type="log4net.Layout.PatternLayout">
+    <conversionPattern value="%newline%-5level %logger %newline - %message" />
+    </layout>
+  </appender>
+  <appender name="SeqAppender" type="Seq.Client.Log4Net.SeqAppender, Seq.Client.Log4Net">
+    <filter type="log4net.Filter.PropertyFilter">
+      <key value="NDC" />
+      <stringToMatch value="Serilog-Log4NetSink" />
+      <acceptOnMatch value="false" />
+    </filter>
+    <bufferSize value="1" />
+    <serverUrl value="http://localhost:5341/" />
+  </appender>
+  <root>
+    <level value="All" />
+    <appender-ref ref="TraceAppender" />
+    <appender-ref ref="SeqAppender" />
+  </root>
+</log4net>
+```
+
 [(More information.)](http://nblumhardt.com/2013/06/serilog-sinks-log4net/)
 

--- a/src/Serilog.Sinks.Log4Net/LoggerConfigurationLog4NetExtensions.cs
+++ b/src/Serilog.Sinks.Log4Net/LoggerConfigurationLog4NetExtensions.cs
@@ -34,18 +34,20 @@ namespace Serilog
         /// Serilog will use this value (which defaults to <code>"serilog"</code>) as the logger name.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="supplyContextMessage">Whether to supply a marker context message to use during the log. See: https://logging.apache.org/log4net/release/manual/contexts.html#stacks </param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Log4Net(
             this LoggerSinkConfiguration loggerConfiguration,
             string defaultLoggerName = "serilog",
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            bool supplyContextMessage = false)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (defaultLoggerName == null) throw new ArgumentNullException("defaultLoggerName");
 
-            return loggerConfiguration.Sink(new Log4NetSink(defaultLoggerName, formatProvider), restrictedToMinimumLevel);
+            return loggerConfiguration.Sink(new Log4NetSink(defaultLoggerName, formatProvider, supplyContextMessage), restrictedToMinimumLevel);
         }
 
         /// <summary>


### PR DESCRIPTION
#### Context Message Marker

Passing `true` for supplyContextMessage, will add a context message of `Serilog-Log4NetSink` scoped just for the log call under the `NDC` stack, which you can utilise for Log4Net filters and other purposes. [See Log4Net documentation](https://logging.apache.org/log4net/release/manual/contexts.html#stacks).

e.g.

``` csharp
var log = new LoggerConfiguration()
    .WriteTo.Log4Net(supplyContextMessage: true)
    .CreateLogger();
```

This can let you specify a filter on an appender in Log4Net. The example below, disables the Seq appender for Log4Net if the context message is present. Useful to stop doubling up logs, for when you have Log4Net and Serilog both pushing to the same sink during migration of logging practices.

``` xml
<log4net>
  <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
    <layout type="log4net.Layout.PatternLayout">
    <conversionPattern value="%newline%-5level %logger %newline - %message" />
    </layout>
  </appender>
  <appender name="SeqAppender" type="Seq.Client.Log4Net.SeqAppender, Seq.Client.Log4Net">
    <filter type="log4net.Filter.PropertyFilter">
      <key value="NDC" />
      <stringToMatch value="Serilog-Log4NetSink" />
      <acceptOnMatch value="false" />
    </filter>
    <bufferSize value="1" />
    <serverUrl value="http://localhost:5341/" />
  </appender>
  <root>
    <level value="All" />
    <appender-ref ref="TraceAppender" />
    <appender-ref ref="SeqAppender" />
  </root>
</log4net>
```
