### PR TITLE
Updated dependency on Serilog to v2.0.0

### DIFF
--- a/src/Serilog.Sinks.Log4Net/Serilog.Sinks.Log4Net.nuspec
+++ b/src/Serilog.Sinks.Log4Net/Serilog.Sinks.Log4Net.nuspec
@@ -11,7 +11,7 @@
       <description>Serilog event sink that writes to Log4Net. Merge your new Serilog event stream into your existing log4net infrastructure.</description>
       <tags>serilog logging log4net</tags>
       <dependencies>
-        <dependency id="Serilog" version="[1.5.6,2)" />
+        <dependency id="Serilog" version="2.0.0" />
         <dependency id="log4net" version="2.0.3" />
       </dependencies>
     </metadata>


### PR DESCRIPTION
Hi Nicholas,

I didn't noticed that dependencies are specified in the nuspec file. For this reason even new version running on Serilog 2.0 was still dependent on version 1.x.x. This is corrected now.

Cheers!
