### PR TITLE
Corrected version of log4net dependency

### DIFF
--- a/src/Serilog.Sinks.Log4Net/Serilog.Sinks.Log4Net.nuspec
+++ b/src/Serilog.Sinks.Log4Net/Serilog.Sinks.Log4Net.nuspec
@@ -12,7 +12,7 @@
       <tags>serilog logging log4net</tags>
       <dependencies>
         <dependency id="Serilog" version="2.0.0" />
-        <dependency id="log4net" version="2.0.3" />
+        <dependency id="log4net" version="2.0.5" />
       </dependencies>
     </metadata>
 </package>


### PR DESCRIPTION
Hi there,

As I upgraded log4net when I was updating serilog as well, the dependency on log4net needs to be updated in NuGet package as well. Sorry for that.

The Sink was not working when using log4net v2.0.3 with new version of the sink.

Maybe worth taking dependencies from nuspec file out and let Nuget resolve dependencies on the fly when creating the package or modify csproj to rely only on major version of log4net. What do you think?

Cheers!
